### PR TITLE
build: use Webpack to build ExtPlug core, closes #30

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-extplug": "^1.0.0",
     "babel-preset-stage-2": "^6.5.0",
-    "browserify": "^11.0.1",
     "del": "^1.2.1",
     "eslint": "^3.0.1",
     "eslint-config-airbnb-base": "^4.0.0",
@@ -38,7 +37,7 @@
     "mkdirp": "^0.5.1",
     "requirejs": "^2.1.20",
     "run-sequence": "^1.1.2",
-    "vinyl-source-stream": "^1.1.0"
+    "webpack": "^1.13.1"
   },
   "scripts": {
     "prepublish": "npm run build",

--- a/src/ExtPlug.js
+++ b/src/ExtPlug.js
@@ -31,6 +31,9 @@ import inlineChatStyles from './styles/inline-chat';
 import settingsPaneStyles from './styles/settings-pane';
 import pluginDialogStyles from './styles/install-plugin-dialog';
 
+// Enable compatibility with AMD-based plugins.
+import './util/compatibility';
+
 // LocalStorage key name for extplug
 const LS_NAME = 'extPlugins';
 

--- a/src/loader.js.template
+++ b/src/loader.js.template
@@ -16,6 +16,7 @@
     var require = window.requirejs;
     var define = window.define;
     <%= code %>
+    require(['extplug/loader']);
   }
   else {
     setTimeout(load, 20);

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 import plugModules from 'plug-modules';
 
+const EXTPLUG_MODULE = 'extplug/__internalExtPlug__';
+
 function waitFor(cond, fn) {
   const i = setInterval(() => {
     if (cond()) {
@@ -24,11 +26,13 @@ function appViewExists() {
 plugModules.run();
 plugModules.register();
 
-window.require(['extplug/ExtPlug'], ExtPlug => {
-  waitFor(appViewExists, () => {
-    const ext = new ExtPlug();
-    window.extp = ext;
+waitFor(appViewExists, () => {
+  window.define('extplug', [EXTPLUG_MODULE], ExtPlug => new ExtPlug());
 
+  window.requirejs(['extplug'], ext => {
+    window.requirejs.undef(EXTPLUG_MODULE);
+
+    window.extp = ext;
     ext.enable();
   });
 });

--- a/src/util/compatibility.js
+++ b/src/util/compatibility.js
@@ -1,0 +1,11 @@
+import * as meld from 'meld';
+import Plugin from '../Plugin';
+import * as request from './request';
+import getUserClasses from './getUserClasses';
+import Style from './Style';
+
+window.define('meld', () => meld);
+window.define('extplug/Plugin', () => Plugin);
+window.define('extplug/util/request', () => request);
+window.define('extplug/util/getUserClasses', () => getUserClasses);
+window.define('extplug/util/Style', () => Style);


### PR DESCRIPTION
Needs updating to match https://github.com/extplug/ExtPlug/issues/30#issuecomment-238987769 and probably also needs to export a bunch more stuff (some Settings views for example) in the main `require(['extplug'])` export.

This uses Webpack to build ExtPlug core, and then the require.js optimizer to bundle it and plug-modules together. It needs to be done this way because ExtPlug core requires plug-modules to have run before loading core.
